### PR TITLE
Enable INFO level logging for keripy witnesses

### DIFF
--- a/src/keri/app/cli/commands/witness/start.py
+++ b/src/keri/app/cli/commands/witness/start.py
@@ -50,8 +50,8 @@ parser.add_argument("--cafilepath", action="store", required=False, default=None
 
 
 def launch(args):
-    help.ogler.level = logging.CRITICAL
-    help.ogler.reopen(name=args.name, temp=True, clear=True)
+    help.ogler.level = logging.INFO
+    help.ogler.reopen(name=args.name, temp=True, clear=True)  # need to configure for logging persistent file
 
     logger = help.ogler.getLogger()
 

--- a/src/keri/app/cli/commands/witness/start.py
+++ b/src/keri/app/cli/commands/witness/start.py
@@ -47,10 +47,11 @@ parser.add_argument('--config-file',
 parser.add_argument("--keypath", action="store", required=False, default=None)
 parser.add_argument("--certpath", action="store", required=False, default=None)
 parser.add_argument("--cafilepath", action="store", required=False, default=None)
+parser.add_argument("--loglevel", action="store", required=False, default="CRITICAL", help="Set log level to DEBUG | INFO | WARNING | ERROR | CRITICAL. Default is CRITICAL")
 
 
 def launch(args):
-    help.ogler.level = logging.INFO
+    help.ogler.level = logging.getLevelName(args.loglevel)
     help.ogler.reopen(name=args.name, temp=True, clear=True)  # need to configure for logging persistent file
 
     logger = help.ogler.getLogger()


### PR DESCRIPTION
keripy INFO level logs cover most of the cases.

hio.help.ogling module provides Ogler class for global logging in keripy. The class can print log to

- console
- syslog
- file