### PR TITLE
fix: stop witness start double-opening the reg LMDB env (1.3 line)

### DIFF
--- a/src/keri/app/indirecting.py
+++ b/src/keri/app/indirecting.py
@@ -93,7 +93,7 @@ def setupWitness(hby, alias="witness", mbx=None, aids=None, tcpPort=5631, httpPo
     app.add_route("/", httpEnd)
     receiptEnd = ReceiptEnd(hab=hab, inbound=cues, aids=aids)
     app.add_route("/receipts", receiptEnd)
-    queryEnd = QueryEnd(hab=hab)
+    queryEnd = QueryEnd(hab=hab, reger=reger)
     app.add_route("/query", queryEnd)
     metricsEnd = EscrowEnd(hby=hby, reger=reger)
     app.add_route("/metrics", metricsEnd)
@@ -1202,9 +1202,12 @@ class QueryEnd:
 
      """
 
-    def __init__(self, hab):
+    def __init__(self, hab, reger=None):
         self.hab = hab
-        self.reger = viring.Reger(name=hab.name, db=hab.db, temp=False)
+        # Reuse the witness's shared Reger rather than opening a SECOND LMDB env on the same
+        # reg path — two env handles for one path in a process raise LMDB's "already open in
+        # this process" and abort witness start (matches keri main, which threads the reger in).
+        self.reger = reger if reger is not None else viring.Reger(name=hab.name, db=hab.db, temp=False)
 
     def on_get(self, req, rep):
         """ Handles GET requests to query KEL or TEL events of a pre from a witness.

--- a/src/keri/db/dbing.py
+++ b/src/keri/db/dbing.py
@@ -416,6 +416,18 @@ class LMDBer(filing.Filer):
         if readonly is not None:
             self.readonly = readonly
 
+        # close self.env if already open so reopen() is idempotent: LMDB raises
+        # "The environment '<path>' is already open in this process" if the same
+        # path is opened twice in one process. The witness start path opens the
+        # reg env at Reger construction and again via its BaserDoer, so without
+        # this close-first the witness aborts at "Starting witness...".
+        if self.env:
+            try:
+                self.env.close()
+            except:  # noqa: E722 - best-effort close before reopen (matches keri main)
+                pass
+
+        self.env = None
         # open lmdb major database instance
         # creates files data.mdb and lock.mdb in .dbDirPath
         self.env = lmdb.open(self.path, max_dbs=self.MaxNamedDBs, map_size=self.MapSize,


### PR DESCRIPTION
## Problem

On this 1.3 line, `kli witness start` aborts at **"Starting witness..."** with:

```
lmdb.Error: The environment '/home/witness/.keri/reg/witness' is already open in this process.
```

Two independent code paths open the **same** `reg` (credential registry) LMDB path in one process, which LMDB forbids:

1. **`QueryEnd.__init__` created its own `Reger(name=hab.name, …)`** on the same reg path as `setupWitness`'s shared `reger` — a second env handle for the same path.
2. **`LMDBer.reopen()` called `lmdb.open()` without first closing an already-open env**, so reopening the reg via its `BaserDoer` opened a second handle on the same path.

## Fix (both are backports of what `keri` main already does)

1. Thread the shared reger into `QueryEnd` — `QueryEnd(hab, reger)` reuses it instead of opening a second env (`setupWitness` now passes `reger=reger`).
2. Make `LMDBer.reopen()` idempotent — close `self.env` (best-effort) and null it before re-opening.

## Validation

Built a witness image from this branch (`keri` @ this fix + hio 0.7.19 + Python 3.14.5) and ran it:

- **Before:** container aborts at `Starting witness...` → the `lmdb.Error` above; never becomes ready.
- **After:** boots cleanly — `Starting witness...` → `Witness witness : BBDzeCI8m9Ls3OBw_LTOnJSEUyWXMD-Xggp4ufqeAE_9`, and `GET /oobi/<AID>/controller` → **200**.

Verified end-to-end through the `witness-qualifier` black-box acceptance harness (full C1–C19 + Tier-P bar).

Found while evaluating the keri 1.3 line as a deployable witness closure — it was the only thing blocking it.