### PR TITLE
Fix $ref resolution when a schema is referenced by SAID alone

### DIFF
--- a/src/keri/core/scheming.py
+++ b/src/keri/core/scheming.py
@@ -76,11 +76,26 @@ class CacheResolver:
         Returns a jsonschema resolver for returning locally cached schema based on self-addressing
         identifier URIs.
 
+        A schema can point at another schema (e.g. to extend it) by putting
+        that schema's identifier in a $ref value. This resolver knows how to
+        look up two forms of $ref:
+          - "did:"-scheme URIs (e.g. "did:keri:<SAID>"), via .handler
+          - a bare SAID with no URI scheme at all (e.g. just
+            "EAbc123..."), looked up in a jsonschema `store` built here
+            from every schema already cached locally in .db.schema
+
+        Note: .db.schema is keyed by each schema's own verified
+        SAID (see CacheResolver.add), so building the store from it cannot
+        be used to swap in a different schema under a given SAID.
+
         Parameters:
             scer (Optional(bytes)) is the source document that is being processed for reference resolution
 
         """
-        return jsonschema.RefResolver("", scer, handlers={"did": self.handler})
+        store = {}
+        for (said,), schemer in self.db.schema.getItemIter():
+            store[said] = schemer.sed
+        return jsonschema.RefResolver("", scer, store=store, handlers={"did": self.handler})
 
 
 class JSONSchema:
@@ -267,7 +282,7 @@ class Schemer:
     """
 
     def __init__(self, raw=b'', sed=None, kind=None, typ=JSONSchema(),
-                       code=MtrDex.Blake3_256, verify=True):
+                       code=MtrDex.Blake3_256, verify=True, resolver=None):
         """  Initialize instance of Schemer
 
         Deserialize if raw provided
@@ -278,7 +293,8 @@ class Schemer:
             raw (bytes): of serialized schema
             sed (dict): dict or None
                   if None its deserialized from raw
-            typ (JSONSchema): type of schema
+            typ (JSONSchema): type of schema. Only honored when sed (not raw)
+                is provided; see resolver below for the raw case.
             kind (serialization): kind string value or None (see namedtuple coring.Serials)
                 supported kinds are 'json', 'cbor', 'msgpack', 'binary'
                  if kind (None): then its extracted from ked or raw
@@ -288,10 +304,21 @@ class Schemer:
                            False means don't verify. Useful to avoid unnecessary
                            reverification when deserializing from database
                            as opposed to over the wire reception.
+            resolver (Optional(CacheResolver)): used to resolve any $ref
+                values in the schema (e.g. one schema extending another).
+                Only used when raw is provided. Deserializing from raw
+                always auto-detects the schema type via ._sniff and
+                overwrites typ with the freshly-detected one -- so a typ
+                passed in above, and any resolver it carried, would
+                otherwise be silently thrown away. Passing resolver here
+                lets ._sniff carry it into that freshly-detected typ
+                instead. Has no effect when sed is provided; pass a
+                resolver-bearing typ directly in that case instead.
 
         """
 
         self._code = code
+        self._resolver = resolver
         if raw:
             self.raw = raw
         elif sed:
@@ -333,8 +360,7 @@ class Schemer:
 
         return raw, sed, kind, saider
 
-    @staticmethod
-    def _sniff(raw):
+    def _sniff(self, raw):
         """ Determine type of schema from raw bytes
 
         Parameters:
@@ -346,10 +372,10 @@ class Schemer:
         except ValueError:
             pass
         else:
-            return JSONSchema()
+            return JSONSchema(resolver=self._resolver)
 
         # Default for now is JSONSchema because we don't support any other
-        return JSONSchema()
+        return JSONSchema(resolver=self._resolver)
 
     @property
     def raw(self):

--- a/src/keri/core/scheming.py
+++ b/src/keri/core/scheming.py
@@ -32,6 +32,8 @@ class CacheResolver:
 
         """
         self.db = db
+        self._store = {}
+        self._storeCount = -1  # forces .resolver() to build the store on first use
 
     def add(self, key, schema):
         """ Add schema to cache for resolution
@@ -88,14 +90,30 @@ class CacheResolver:
         SAID (see CacheResolver.add), so building the store from it cannot
         be used to swap in a different schema under a given SAID.
 
+        This method runs once per schema check (see JSONSchema.verify_json),
+        so rebuilding the store from every cached schema on every call would
+        mean re-reading and re-parsing the whole local schema cache on every
+        single credential validation, growing with however many schemas
+        this Habery has ever cached. .db.schema.cntAll() is a cheaper check
+        (it steps through keys only, without deserializing each schema's
+        JSON), and since .db.schema entries are keyed by their own content
+        SAID and are never removed, that count can only change when a
+        schema is added, so it's an exact signal for when the store
+        actually needs rebuilding, at a fraction of the cost of rebuilding
+        it unconditionally.
+
         Parameters:
             scer (Optional(bytes)) is the source document that is being processed for reference resolution
 
         """
-        store = {}
-        for (said,), schemer in self.db.schema.getItemIter():
-            store[said] = schemer.sed
-        return jsonschema.RefResolver("", scer, store=store, handlers={"did": self.handler})
+        count = self.db.schema.cntAll()
+        if count != self._storeCount:
+            store = {}
+            for (said,), schemer in self.db.schema.getItemIter():
+                store[said] = schemer.sed
+            self._store = store
+            self._storeCount = count
+        return jsonschema.RefResolver("", scer, store=self._store, handlers={"did": self.handler})
 
 
 class JSONSchema:

--- a/src/keri/vdr/credentialing.py
+++ b/src/keri/vdr/credentialing.py
@@ -831,7 +831,7 @@ class Credentialer(doing.DoDoer):
             raise kering.ConfigurationError("Credential schema {} not found.  It must be loaded with data oobi before "
                                             "issuing credentials".format(schema))
 
-        schemer = scheming.Schemer(raw=scraw)
+        schemer = scheming.Schemer(raw=scraw, resolver=self.verifier.resolver)
         try:
             schemer.verify(creder.raw)
         except kering.ValidationError as ex:

--- a/src/keri/vdr/verifying.py
+++ b/src/keri/vdr/verifying.py
@@ -133,7 +133,7 @@ class Verifier:
                 self.cues.append(dict(kin="query", q=dict(r="schema", said=schema)))
             raise kering.MissingSchemaError("schema {} not in cache".format(schema))
 
-        schemer = scheming.Schemer(raw=scraw)
+        schemer = scheming.Schemer(raw=scraw, resolver=self.resolver)
         try:
             schemer.verify(creder.raw)
         except kering.ValidationError as ex:

--- a/tests/core/test_scheming.py
+++ b/tests/core/test_scheming.py
@@ -424,6 +424,145 @@ def test_resolution_no_ref_with_resolver_present():
             schemer.verify(b'{}')
 
 
+def test_cache_resolver_resolver_store_is_cached():
+    """ CacheResolver.resolver() rebuilds its jsonschema store from every
+    schema in db.schema, which would mean re-reading and re-parsing that
+    entire local cache on every single credential check if done on every
+    call. It should instead reuse the store across calls as long as
+    db.schema hasn't changed, and only rebuild once a new schema is added.
+    """
+    basesad = {
+        "$id": "",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "required": ["z"],
+        "properties": {"z": {"type": "number"}},
+    }
+    saider, basesad = Saider.saidify(basesad, label=Saids.dollar)
+    basesaid = saider.qb64
+    base = dumps(basesad)
+
+    with basing.openDB(name="cache-resolver-store-caching") as db:
+        cache = CacheResolver(db=db)
+
+        calls = []
+        realGetItemIter = db.schema.getItemIter
+
+        def countedGetItemIter(*pa, **kwa):
+            calls.append(1)
+            return realGetItemIter(*pa, **kwa)
+
+        db.schema.getItemIter = countedGetItemIter
+
+        cache.resolver()
+        cache.resolver()
+        cache.resolver()
+        assert len(calls) == 1  # nothing changed in db.schema; store built once, then reused
+
+        cache.add(basesaid, base)
+
+        r = cache.resolver()
+        assert basesaid in r.store  # new schema is picked up
+        assert len(calls) == 2  # db.schema changed; store was rebuilt exactly once more
+
+        cache.resolver()
+        assert len(calls) == 2  # unchanged again since the rebuild; still reused
+
+
+def test_cache_resolver_store_not_mutated_by_resolution():
+    """ CacheResolver._store is reused across .resolver() calls, so nothing
+    resolving against it, a hit or a miss, on any $ref style, may leave
+    it changed afterward. jsonschema.RefResolver copies the store it's
+    given at construction time rather than holding a reference to it, so
+    this holds today; this test exists to catch it directly if that ever
+    stops being true.
+    """
+    refsad = {
+        "$id": "",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "required": ["z"],
+        "properties": {"z": {"type": "number"}},
+    }
+    saider, refsad = Saider.saidify(refsad, label=Saids.dollar)
+    refsaid = saider.qb64
+    ref = dumps(refsad)
+
+    sad = {
+        "$id": "",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "allOf": [
+            {"$ref": ""},
+            {
+                "type": "object",
+                "required": ["a"],
+                "properties": {"a": {"type": "string"}},
+            },
+        ],
+    }
+    sad["allOf"][0]["$ref"] = f"did:keri:{refsaid}"
+    saider, sad = Saider.saidify(sad, label=Saids.dollar)
+    raw = dumps(sad)
+
+    with basing.openDB(name="cache-resolver-store-not-mutated") as db:
+        cache = CacheResolver(db=db)
+        schemer = Schemer(raw=raw)
+        schemer.typ = JSONSchema(resolver=cache)
+
+        # miss: refsaid not cached yet -- CacheResolver._store must stay
+        # untouched by the failed lookup
+        with pytest.raises(ValidationError):
+            schemer.verify(b'{"a": "x", "z": 1}')
+        assert cache._store == {}
+
+        cache.add(refsaid, ref)
+
+        # hit: refsaid now resolves -- CacheResolver._store must contain
+        # only what it built from db.schema, not anything jsonschema's own
+        # did: resolution added on top of that
+        assert schemer.verify(b'{"a": "x", "z": 1}') is True
+        assert set(cache._store.keys()) == {refsaid}
+
+
+def test_cache_resolver_missing_ref_fails_the_same_way_on_repeated_calls():
+    """ Two failed lookups for the same unresolvable $ref, with nothing
+    added to db.schema in between, must fail the same clean way both
+    times -- not succeed incorrectly, and not fail differently or worse
+    the second time around because the store was reused instead of
+    rebuilt from scratch.
+    """
+    sad = {
+        "$id": "",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "allOf": [
+            {"$ref": "did:keri:EDoesNotExistInLocalCache00000000000000000"},
+            {"type": "object"},
+        ],
+    }
+    saider, sad = Saider.saidify(sad, label=Saids.dollar)
+    raw = dumps(sad)
+
+    with basing.openDB(name="cache-resolver-repeated-miss") as db:
+        cache = CacheResolver(db=db)
+        schemer = Schemer(raw=raw)
+        schemer.typ = JSONSchema(resolver=cache)
+
+        first = None
+        second = None
+        try:
+            schemer.verify(b'{}')
+        except ValidationError as ex:
+            first = str(ex)
+
+        try:
+            schemer.verify(b'{}')
+        except ValidationError as ex:
+            second = str(ex)
+
+        assert first is not None
+        assert first == second
+
+
 if __name__ == '__main__':
     test_json_schema()
     test_json_schema_dict()

--- a/tests/core/test_scheming.py
+++ b/tests/core/test_scheming.py
@@ -295,6 +295,135 @@ def test_resolution():
             schemer.verify(badload)
 
 
+def test_resolution_bare_said_ref():
+    """ Test resolving a bare-SAID $ref (no "did:" scheme prefix) via
+    CacheResolver, including a two-level chain to confirm transitive
+    resolution and that a field required only by the middle schema in the
+    chain is still enforced.
+    """
+    basesad = {
+        "$id": "",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "required": ["z"],
+        "properties": {"z": {"type": "number"}},
+    }
+    saider, basesad = Saider.saidify(basesad, label=Saids.dollar)
+    basesaid = saider.qb64
+    base = dumps(basesad)
+
+    midsad = {
+        "$id": "",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "allOf": [
+            {"$ref": ""},
+            {
+                "type": "object",
+                "required": ["m"],
+                "properties": {"m": {"type": "string"}},
+            },
+        ],
+    }
+    midsad["allOf"][0]["$ref"] = basesaid
+    saider, midsad = Saider.saidify(midsad, label=Saids.dollar)
+    midsaid = saider.qb64
+    mid = dumps(midsad)
+
+    topsad = {
+        "$id": "",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "allOf": [
+            {"$ref": ""},
+            {
+                "type": "object",
+                "required": ["t"],
+                "properties": {"t": {"type": "string"}},
+            },
+        ],
+    }
+    topsad["allOf"][0]["$ref"] = midsaid
+    saider, topsad = Saider.saidify(topsad, label=Saids.dollar)
+    top = dumps(topsad)
+
+    good = json.dumps({"z": 1, "m": "x", "t": "y"}).encode("utf-8")
+    missingMid = json.dumps({"z": 1, "t": "y"}).encode("utf-8")
+    missingBase = json.dumps({"m": "x", "t": "y"}).encode("utf-8")
+    missingTop = json.dumps({"z": 1, "m": "x"}).encode("utf-8")
+
+    with basing.openDB(name="bare-said-ref") as db:
+        cache = CacheResolver(db=db)
+        cache.add(basesaid, base)  # only base and mid are pre-cached; top is the schema under test
+        cache.add(midsaid, mid)
+
+        schemer = Schemer(raw=top)
+        schemer.typ = JSONSchema(resolver=cache)
+
+        assert schemer.verify(good) is True
+
+        # each level's required field must still be independently enforced
+        # through the chain, not short-circuited by the other levels passing
+        with pytest.raises(ValidationError):
+            schemer.verify(missingMid)
+
+        with pytest.raises(ValidationError):
+            schemer.verify(missingBase)
+
+        with pytest.raises(ValidationError):
+            schemer.verify(missingTop)
+
+
+def test_resolution_unresolvable_bare_said_ref():
+    """ A bare-SAID $ref to a schema that was never cached locally must still
+    fail closed, not be silently treated as satisfied.
+    """
+    sad = {
+        "$id": "",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "allOf": [
+            {"$ref": "EDoesNotExistInLocalCache00000000000000000"},
+            {"type": "object"},
+        ],
+    }
+    saider, sad = Saider.saidify(sad, label=Saids.dollar)
+    raw = dumps(sad)
+
+    with basing.openDB(name="unresolvable-said-ref") as db:
+        cache = CacheResolver(db=db)  # nothing added to the cache
+
+        schemer = Schemer(raw=raw)
+        schemer.typ = JSONSchema(resolver=cache)
+
+        with pytest.raises(ValidationError):
+            schemer.verify(b'{}')
+
+
+def test_resolution_no_ref_with_resolver_present():
+    """ A plain schema with no $ref at all must still validate normally when
+    a resolver is attached, i.e. attaching a resolver must not change
+    behavior for schemas that don't use it.
+    """
+    sad = {
+        "$id": "",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "required": ["a"],
+        "properties": {"a": {"type": "string"}},
+    }
+    saider, sad = Saider.saidify(sad, label=Saids.dollar)
+    raw = dumps(sad)
+
+    with basing.openDB(name="no-ref-with-resolver") as db:
+        cache = CacheResolver(db=db)
+
+        schemer = Schemer(raw=raw)
+        schemer.typ = JSONSchema(resolver=cache)
+
+        assert schemer.verify(b'{"a": "x"}') is True
+
+        with pytest.raises(ValidationError):
+            schemer.verify(b'{}')
+
+
 if __name__ == '__main__':
     test_json_schema()
     test_json_schema_dict()

--- a/tests/vdr/test_credentialing.py
+++ b/tests/vdr/test_credentialing.py
@@ -1,0 +1,182 @@
+# -*- encoding: utf-8 -*-
+"""
+tests.vdr.credentialing module
+
+"""
+from keri import kering
+from keri.app import habbing
+from keri.core import coring, scheming
+from keri.vc import proving
+from keri.vdr import credentialing, verifying
+
+
+def _pinChainedSchema(db):
+    """ Pin a base schema and a derived schema into db.schema, where the
+    derived schema's top-level allOf[0].$ref is the base schema's bare SAID
+    (no "did:" scheme prefix). The base schema requires an attribute ("z")
+    that only the base contributes, and the derived schema separately
+    requires its own attribute ("m"), so tests can independently prove
+    each half of the chain is enforced.
+
+    Returns:
+        tuple(str, str): (base schema SAID, derived schema SAID)
+    """
+    basesad = {
+        "$id": "",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "Base",
+        "type": "object",
+        "required": ["v", "d", "i", "s", "a"],
+        "properties": {
+            "v": {"type": "string"},
+            "d": {"type": "string"},
+            "i": {"type": "string"},
+            "s": {"type": "string"},
+            "a": {
+                "type": "object",
+                "additionalProperties": True,
+                "required": ["d", "z"],
+                "properties": {
+                    "d": {"type": "string"},
+                    "z": {"type": "string"},
+                },
+            },
+        },
+    }
+    _, basesad = coring.Saider.saidify(basesad, label=coring.Saids.dollar)
+    baseschemer = scheming.Schemer(sed=basesad)
+    db.schema.pin(keys=(baseschemer.said,), val=baseschemer)
+
+    derivedsad = {
+        "$id": "",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "Derived",
+        "allOf": [
+            {"$ref": ""},
+            {
+                "type": "object",
+                "additionalProperties": True,
+                "required": ["ri"],
+                "properties": {
+                    "ri": {"type": "string"},
+                    "a": {
+                        "type": "object",
+                        "additionalProperties": True,
+                        "required": ["m"],
+                        "properties": {"m": {"type": "string"}},
+                    },
+                },
+            },
+        ],
+    }
+    derivedsad["allOf"][0]["$ref"] = baseschemer.said
+    _, derivedsad = coring.Saider.saidify(derivedsad, label=coring.Saids.dollar)
+    derivedschemer = scheming.Schemer(sed=derivedsad)
+    db.schema.pin(keys=(derivedschemer.said,), val=derivedschemer)
+
+    return baseschemer.said, derivedschemer.said
+
+
+def test_credentialer_create_chained_schema():
+    """ Credentialer.create() -> validate() must succeed for a credential
+    issued against a schema that inherits from a base schema via a
+    bare-SAID $ref, and must still enforce requirements contributed by
+    *either* half of the chain independently.
+    """
+    with habbing.openHab(name="issuer", temp=True, salt=b'0123456789abcdef') as (hby, hab):
+        basesaid, derivedsaid = _pinChainedSchema(hby.db)
+
+        regery = credentialing.Regery(hby=hby, name="issuer", temp=True)
+        registry = regery.makeRegistry(prefix=hab.pre, name="test")
+
+        verifier = verifying.Verifier(hby=hby, reger=regery.reger)
+        credentialer = credentialing.Credentialer(hby=hby, rgy=regery, registrar=None, verifier=verifier)
+
+        # satisfies both the base-contributed requirement (a.z) and the
+        # derived-only requirement (a.m)
+        creder = credentialer.create(regname="test", recp=None, schema=derivedsaid,
+                                     source=None, rules=None, data={"z": "zval", "m": "mval"})
+        assert creder.sad["s"] == derivedsaid
+        assert creder.sad["a"]["z"] == "zval"
+        assert creder.sad["a"]["m"] == "mval"
+
+        # sanity: the base schema alone is still resolvable/usable on its own
+        assert hby.db.schema.get(keys=(basesaid,)) is not None
+
+
+def test_credentialer_create_chained_schema_missing_base_required_field():
+    """ A credential that satisfies the derived schema's own requirements
+    but omits a field required only by the inherited base schema must still
+    be rejected -- proves the fix doesn't just make $ref "always pass", it
+    actually resolves and enforces the base schema's constraints.
+    """
+    with habbing.openHab(name="issuer", temp=True, salt=b'0123456789abcdef') as (hby, hab):
+        _, derivedsaid = _pinChainedSchema(hby.db)
+
+        regery = credentialing.Regery(hby=hby, name="issuer", temp=True)
+        regery.makeRegistry(prefix=hab.pre, name="test")
+
+        verifier = verifying.Verifier(hby=hby, reger=regery.reger)
+        credentialer = credentialing.Credentialer(hby=hby, rgy=regery, registrar=None, verifier=verifier)
+
+        try:
+            credentialer.create(regname="test", recp=None, schema=derivedsaid,
+                                source=None, rules=None, data={"m": "mval"})  # missing base-required 'z'
+            assert False, "expected ConfigurationError for missing base-required field"
+        except kering.ConfigurationError as ex:
+            assert "Credential schema validation failed" in str(ex)
+
+
+def test_credentialer_create_chained_schema_missing_derived_required_field():
+    """ A credential that satisfies the inherited base schema but omits a
+    field required only by the derived schema's own (non-$ref) allOf branch
+    must still be rejected -- proves the derived branch isn't short-circuited
+    once the $ref branch resolves.
+    """
+    with habbing.openHab(name="issuer", temp=True, salt=b'0123456789abcdef') as (hby, hab):
+        _, derivedsaid = _pinChainedSchema(hby.db)
+
+        regery = credentialing.Regery(hby=hby, name="issuer", temp=True)
+        regery.makeRegistry(prefix=hab.pre, name="test")
+
+        verifier = verifying.Verifier(hby=hby, reger=regery.reger)
+        credentialer = credentialing.Credentialer(hby=hby, rgy=regery, registrar=None, verifier=verifier)
+
+        try:
+            credentialer.create(regname="test", recp=None, schema=derivedsaid,
+                                source=None, rules=None, data={"z": "zval"})  # missing derived-required 'm'
+            assert False, "expected ConfigurationError for missing derived-required field"
+        except kering.ConfigurationError as ex:
+            assert "Credential schema validation failed" in str(ex)
+
+
+def test_credentialer_create_unresolvable_ref_schema():
+    """ If the base schema a derived schema $refs was never cached locally,
+    issuance must still fail closed with a clear error, not silently
+    succeed or crash uncontrolled.
+    """
+    with habbing.openHab(name="issuer", temp=True, salt=b'0123456789abcdef') as (hby, hab):
+        derivedsad = {
+            "$id": "",
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "allOf": [
+                {"$ref": "EDoesNotExistInLocalCache00000000000000000"},
+                {"type": "object", "required": ["v", "d", "i", "s", "ri"]},
+            ],
+        }
+        _, derivedsad = coring.Saider.saidify(derivedsad, label=coring.Saids.dollar)
+        derivedschemer = scheming.Schemer(sed=derivedsad)
+        hby.db.schema.pin(keys=(derivedschemer.said,), val=derivedschemer)
+
+        regery = credentialing.Regery(hby=hby, name="issuer", temp=True)
+        regery.makeRegistry(prefix=hab.pre, name="test")
+
+        verifier = verifying.Verifier(hby=hby, reger=regery.reger)
+        credentialer = credentialing.Credentialer(hby=hby, rgy=regery, registrar=None, verifier=verifier)
+
+        try:
+            credentialer.create(regname="test", recp=None, schema=derivedschemer.said,
+                                source=None, rules=None, data={})
+            assert False, "expected ConfigurationError for unresolvable $ref"
+        except kering.ConfigurationError as ex:
+            assert "Credential schema validation failed" in str(ex)

--- a/tests/vdr/test_verifying.py
+++ b/tests/vdr/test_verifying.py
@@ -118,6 +118,193 @@ def test_verifier(seeder):
         with pytest.raises(kering.MissingEntryError):
             regery.reger.cloneCred(said="nonexistantsaid")
 
+
+def _pinChainedSchema(db):
+    """ Pin a base schema and a derived schema into db.schema, where the
+    derived schema's top-level allOf[0].$ref is the base schema's bare SAID
+    (no "did:" scheme prefix). The base schema requires attribute "z"; the
+    derived schema separately requires its own attribute "m", so tests can
+    independently prove each half of the chain is enforced.
+
+    Returns:
+        tuple(str, str): (base schema SAID, derived schema SAID)
+    """
+    basesad = {
+        "$id": "",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "Base",
+        "type": "object",
+        "required": ["v", "d", "i", "s", "a"],
+        "properties": {
+            "v": {"type": "string"},
+            "d": {"type": "string"},
+            "i": {"type": "string"},
+            "s": {"type": "string"},
+            "a": {
+                "type": "object",
+                "additionalProperties": True,
+                "required": ["d", "z"],
+                "properties": {
+                    "d": {"type": "string"},
+                    "z": {"type": "string"},
+                },
+            },
+        },
+    }
+    _, basesad = coring.Saider.saidify(basesad, label=coring.Saids.dollar)
+    baseschemer = scheming.Schemer(sed=basesad)
+    db.schema.pin(keys=(baseschemer.said,), val=baseschemer)
+
+    derivedsad = {
+        "$id": "",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "Derived",
+        "allOf": [
+            {"$ref": ""},
+            {
+                "type": "object",
+                "additionalProperties": True,
+                "required": ["ri"],
+                "properties": {
+                    "ri": {"type": "string"},
+                    "a": {
+                        "type": "object",
+                        "additionalProperties": True,
+                        "required": ["m"],
+                        "properties": {"m": {"type": "string"}},
+                    },
+                },
+            },
+        ],
+    }
+    derivedsad["allOf"][0]["$ref"] = baseschemer.said
+    _, derivedsad = coring.Saider.saidify(derivedsad, label=coring.Saids.dollar)
+    derivedschemer = scheming.Schemer(sed=derivedsad)
+    db.schema.pin(keys=(derivedschemer.said,), val=derivedschemer)
+
+    return baseschemer.said, derivedschemer.said
+
+
+def test_verifier_chained_schema():
+    """ Verifier.processCredential() -- the path keripy uses to validate a
+    credential presented by someone else (e.g. over IPEX) -- must accept a
+    credential whose schema inherits from a base schema via a bare-SAID
+    $ref, and must still enforce requirements contributed by either half of
+    the chain. See also test_credentialing.py::test_credentialer_create_chained_schema,
+    which covers the same $ref resolution for the self-issuance call site.
+    """
+    with habbing.openHab(name="sid", temp=True, salt=b'0123456789abcdef') as (hby, hab), \
+            habbing.openHab(name="recp", transferable=True, temp=True) as (recpHby, recp):
+        basesaid, derivedsaid = _pinChainedSchema(hby.db)
+
+        regery = credentialing.Regery(hby=hby, name="test", temp=True)
+        issuer = regery.makeRegistry(prefix=hab.pre, name="test")
+        rseal = SealEvent(issuer.regk, "0", issuer.regd)._asdict()
+        hab.interact(data=[rseal])
+        seqner = coring.Seqner(sn=hab.kever.sn)
+        issuer.anchorMsg(pre=issuer.regk,
+                         regd=issuer.regd,
+                         seqner=seqner,
+                         saider=coring.Saider(qb64=hab.kever.serder.said))
+        regery.processEscrows()
+
+        verifier = verifying.Verifier(hby=hby, reger=regery.reger)
+
+        credSubject = dict(
+            d="",
+            i=recp.pre,
+            dt=helping.nowIso8601(),
+            z="zval",
+            m="mval",
+        )
+        _, d = scheming.Saider.saidify(sad=credSubject, code=coring.MtrDex.Blake3_256, label=scheming.Saids.d)
+
+        creder = proving.credential(issuer=hab.pre,
+                                    schema=derivedsaid,
+                                    data=d,
+                                    status=issuer.regk)
+
+        try:
+            verifier.processCredential(creder, prefixer=hab.kever.prefixer, seqner=seqner,
+                                       saider=coring.Saider(qb64=hab.kever.serder.said))
+        except kering.MissingRegistryError:
+            pass  # expected: TEL anchor not escrowed/found yet, same as test_verifier above
+
+        assert len(verifier.cues) == 1
+        cue = verifier.cues.popleft()
+        assert cue["kin"] == "telquery"
+
+        iss = issuer.issue(said=creder.said)
+        rseal = SealEvent(iss.pre, "0", iss.said)._asdict()
+        hab.interact(data=[rseal])
+        seqner = coring.Seqner(sn=hab.kever.sn)
+        issuer.anchorMsg(pre=iss.pre,
+                         regd=iss.said,
+                         seqner=seqner,
+                         saider=coring.Saider(qb64=hab.kever.serder.said))
+        regery.processEscrows()
+
+        verifier.processEscrows()
+
+        assert len(verifier.cues) == 1
+        cue = verifier.cues.popleft()
+        assert cue["kin"] == "saved"
+        assert cue["creder"].raw == creder.raw
+
+
+def test_verifier_chained_schema_missing_base_required_field():
+    """ A credential presented for verification that satisfies the derived
+    schema but omits a field required only by the inherited base schema
+    must still be rejected by Verifier.processCredential(), once the
+    registry/TEL state is otherwise all in place (i.e. it's specifically
+    the schema check that rejects it, not a registry/anchor precondition).
+    """
+    with habbing.openHab(name="sid", temp=True, salt=b'0123456789abcdef') as (hby, hab), \
+            habbing.openHab(name="recp", transferable=True, temp=True) as (recpHby, recp):
+        _, derivedsaid = _pinChainedSchema(hby.db)
+
+        regery = credentialing.Regery(hby=hby, name="test", temp=True)
+        issuer = regery.makeRegistry(prefix=hab.pre, name="test")
+        rseal = SealEvent(issuer.regk, "0", issuer.regd)._asdict()
+        hab.interact(data=[rseal])
+        seqner = coring.Seqner(sn=hab.kever.sn)
+        issuer.anchorMsg(pre=issuer.regk,
+                         regd=issuer.regd,
+                         seqner=seqner,
+                         saider=coring.Saider(qb64=hab.kever.serder.said))
+        regery.processEscrows()
+
+        verifier = verifying.Verifier(hby=hby, reger=regery.reger)
+
+        credSubject = dict(
+            d="",
+            i=recp.pre,
+            dt=helping.nowIso8601(),
+            m="mval",  # base-required 'z' deliberately omitted
+        )
+        _, d = scheming.Saider.saidify(sad=credSubject, code=coring.MtrDex.Blake3_256, label=scheming.Saids.d)
+
+        creder = proving.credential(issuer=hab.pre,
+                                    schema=derivedsaid,
+                                    data=d,
+                                    status=issuer.regk)
+
+        # issue + anchor the TEL event first so the registry/state checks in
+        # processCredential() pass through to the schema check in this one call
+        iss = issuer.issue(said=creder.said)
+        rseal = SealEvent(iss.pre, "0", iss.said)._asdict()
+        hab.interact(data=[rseal])
+        seqner = coring.Seqner(sn=hab.kever.sn)
+        issuer.anchorMsg(pre=iss.pre,
+                         regd=iss.said,
+                         seqner=seqner,
+                         saider=coring.Saider(qb64=hab.kever.serder.said))
+        regery.processEscrows()
+
+        with pytest.raises(kering.FailedSchemaValidationError):
+            verifier.processCredential(creder, prefixer=hab.kever.prefixer, seqner=seqner,
+                                       saider=coring.Saider(qb64=hab.kever.serder.said))
+
     """End Test"""
 
 


### PR DESCRIPTION
A schema can reference another schema by putting its SAID in a $ref value (e.g. one schema extending another via allOf). CacheResolver. resolver() only resolved "did:"-scheme $ref URIs; a $ref that was just the SAID by itself, with no "did:" prefix, always came back Unresolvable, even when the referenced schema was already cached in db.schema. Build the jsonschema resolver's store from db.schema so these SAID-only refs resolve locally too.

Separately, Credentialer.validate() and Verifier.processCredential() never passed a resolver into Schemer at all, so no $ref-based schema could validate through either the issuance or the verification path. Schemer.__init__ now accepts an optional resolver argument and passes it through _inhale/_sniff (raw-based construction always re-detects typ, which was silently discarding any resolver passed in before), and both call sites now pass their existing CacheResolver in.